### PR TITLE
Refactor lint rules to return lint information

### DIFF
--- a/server/src/linter/index.js
+++ b/server/src/linter/index.js
@@ -1,10 +1,15 @@
 const rules = require('./rules');
+const { addToDiagnostics } = require('./helper');
 
 module.exports.lint = function (document, docConfig) {
     const diagnostics = [];
     const text = document.getText();
     Object.keys(rules).forEach(function (ruleId) {
-        rules[ruleId].run(document, text, diagnostics);
+        const problems = rules[ruleId].run(text);
+
+        problems.forEach(function ({ startIndex, endIndex, message, severity }) {
+            addToDiagnostics(document, diagnostics, startIndex, endIndex, message, severity);
+        });
     });
     return diagnostics;
 };

--- a/server/src/linter/rules/first_step.js
+++ b/server/src/linter/rules/first_step.js
@@ -1,22 +1,24 @@
+const { DiagnosticSeverity: Severity } = require('vscode-languageserver/node');
 const { globalMatch } = require('../../regex');
 const Keywords = require('../../keywords');
 const Messages = require('../messages');
-const { addToDiagnostics } = require('../helper');
 
 module.exports = {
-    run: function (document, text, diagnostics) {
+    run: function (text) {
+        const problems = [];
         const regex = globalMatch.beginningStep;
 
         while ((match = regex.exec(text))) {
             if (![Keywords.Given, Keywords.When].includes(match[0])) {
-                addToDiagnostics(
-                    document,
-                    diagnostics,
-                    match.index,
-                    match.index + match[0].length,
-                    Messages.firstStepShouldBeGivenOrWhen
-                );
+                problems.push({
+                    startIndex: match.index,
+                    endIndex: match.index + match[0].length,
+                    message: Messages.firstStepShouldBeGivenOrWhen,
+                    severity: Severity.Warning,
+                });
             }
         }
+
+        return problems;
     },
 };

--- a/server/src/linter/rules/only_one_feature.js
+++ b/server/src/linter/rules/only_one_feature.js
@@ -1,10 +1,10 @@
 const { DiagnosticSeverity: Severity } = require('vscode-languageserver/node');
 const { globalMatch } = require('../../regex');
 const Messages = require('../messages');
-const { addToDiagnostics } = require('../helper');
 
 module.exports = {
-    run: function (document, text, diagnostics) {
+    run: function (text) {
+        const problems = [];
         const regex = globalMatch.feature;
         let matchCount = 0;
 
@@ -12,18 +12,23 @@ module.exports = {
             matchCount++;
             // only show error from second match onward
             if (matchCount > 1) {
-                addToDiagnostics(
-                    document,
-                    diagnostics,
-                    match.index,
-                    match.index + match[0].length,
-                    Messages.mustHaveOnlyOneFeature,
-                    Severity.Error
-                );
+                problems.push({
+                    startIndex: match.index,
+                    endIndex: match.index + match[0].length,
+                    message: Messages.mustHaveOnlyOneFeature,
+                    severity: Severity.Error,
+                });
             }
         }
         if (!matchCount) {
-            addToDiagnostics(document, diagnostics, 1, 1, Messages.mustHaveFeatureName, Severity.Error);
+            problems.push({
+                startIndex: 1,
+                endIndex: 1,
+                message: Messages.mustHaveFeatureName,
+                severity: Severity.Error,
+            });
         }
+
+        return problems;
     },
 };


### PR DESCRIPTION
Lint rules are refactored to return lint problems (previously lint problems were added to the diagnostics array directly from the rules).
This also makes the lint rules loosely coupled and testable.

Each lint rules return a list (array) of problem objects.
Problem object structure:
```js
{
  startIndex: number,
  endIndex: number,
  message: string,
  severity: number
}
```