### PR TITLE
Added cancel previous runs on CI

### DIFF
--- a/.github/workflows/test-build-package-release.yml
+++ b/.github/workflows/test-build-package-release.yml
@@ -15,6 +15,12 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
+            - name: Cancel previous runs
+              uses: styfle/cancel-workflow-action@0.9.1
+              with:
+                all_but_latest: true
+                access_token: ${{ secrets.GITHUB_TOKEN }}
+                
             - name: checkout
               uses: actions/checkout@v2
 


### PR DESCRIPTION
This PR adds the steps to cancel previous runs from CI when `PUSH` to PR is triggered.
Fixes https://github.com/gherlint/gherlint-vscode/issues/12